### PR TITLE
Fix message show weird format when only 1 of `{displayname}` or `{message}` is present

### DIFF
--- a/strings-api/src/main/java/com/pedestriamc/strings/api/StringsProvider.java
+++ b/strings-api/src/main/java/com/pedestriamc/strings/api/StringsProvider.java
@@ -43,6 +43,16 @@ public final class StringsProvider{
     }
 
     /**
+     * For internal use only.
+     * @param api API Implementation
+     * @param plugin Strings plugin
+     */
+    public static void unregister(){
+        StringsProvider.api = null;
+        Bukkit.getLogger().info("[Strings] Strings API unloaded.");
+    }
+
+    /**
      * Provides a short of the API version.
      * @return A short of the API version.
      */

--- a/strings-bukkit/src/main/java/com/pedestriamc/strings/Strings.java
+++ b/strings-bukkit/src/main/java/com/pedestriamc/strings/Strings.java
@@ -112,6 +112,7 @@ public final class Strings extends JavaPlugin {
         HandlerList.unregisterAll(this);
         this.getServer().getScheduler().cancelTasks(this);
         this.getServer().getServicesManager().unregister(StringsAPI.class, stringsImpl);
+        StringsProvider.unregister();
         this.stringsImpl = null;
         logger.info("[Strings] Disabled");
     }

--- a/strings-bukkit/src/main/java/com/pedestriamc/strings/chat/ChatManager.java
+++ b/strings-bukkit/src/main/java/com/pedestriamc/strings/chat/ChatManager.java
@@ -42,13 +42,13 @@ public final class ChatManager {
     public @NotNull String formatMessage(Player sender, Channel channel){
         String newMessageFormat = channel.getFormat();
         User user = strings.getUser(sender.getUniqueId());
+        newMessageFormat = newMessageFormat.replace("{prefix}", user.getPrefix());
+        newMessageFormat = newMessageFormat.replace("{suffix}", user.getSuffix());
+        newMessageFormat = newMessageFormat.replace("{displayname}", user.getDisplayName());
+        newMessageFormat = newMessageFormat.replace("{message}", user.getChatColor(channel) + "{message}");
         if(usePAPI){
             newMessageFormat = PlaceholderAPI.setPlaceholders(sender, newMessageFormat);
         }
-        newMessageFormat = newMessageFormat.replace("{prefix}", user.getPrefix());
-        newMessageFormat = newMessageFormat.replace("{suffix}", user.getSuffix());
-        newMessageFormat = newMessageFormat.replace("{displayname}", "%s");
-        newMessageFormat = newMessageFormat.replace("{message}", user.getChatColor(channel) + "%s");
         newMessageFormat = ChatColor.translateAlternateColorCodes('&', newMessageFormat);
 
         return newMessageFormat;
@@ -68,11 +68,11 @@ public final class ChatManager {
         if(mentionsEnabled && sender.hasPermission("strings.*") || sender.hasPermission("strings.mention")) {
             message = processMentions(sender, message);
         }
-        if(parseChatColors && (sender.hasPermission("strings.*") || sender.hasPermission("strings.chat.*") || sender.hasPermission("strings.chat.colormsg"))){
-            message = ChatColor.translateAlternateColorCodes('&', message);
-        }
         if(usePAPI && messagePlaceholders && (sender.hasPermission("strings.*") || sender.hasPermission("strings.chat.*") || sender.hasPermission("strings.chat.placeholdermsg"))){
             message = PlaceholderAPI.setPlaceholders(sender, message);
+        }
+        if(parseChatColors && (sender.hasPermission("strings.*") || sender.hasPermission("strings.chat.*") || sender.hasPermission("strings.chat.colormsg"))){
+            message = ChatColor.translateAlternateColorCodes('&', message);
         }
         return message;
     }

--- a/strings-bukkit/src/main/java/com/pedestriamc/strings/chat/channels/HelpOPChannel.java
+++ b/strings-bukkit/src/main/java/com/pedestriamc/strings/chat/channels/HelpOPChannel.java
@@ -64,13 +64,12 @@ public class HelpOPChannel implements Channel {
         String format = chatManager.formatMessage(player, this);
         message = chatManager.processMessage(player, message);
         String finalMessage = message;
+        String formattedMessage = format.replace("{message}", finalMessage);
         if(callEvent){
             Bukkit.getScheduler().runTask(strings, () ->{
                 AsyncPlayerChatEvent event = new ChannelChatEvent(false, player, finalMessage, members, this.getStringsChannel());
-                event.setFormat(format);
                 Bukkit.getPluginManager().callEvent(event);
                 if(!event.isCancelled()){
-                    String formattedMessage = String.format(event.getFormat(), strings.getUser(player).getDisplayName(), event.getMessage());
                     for(Player p : members){
                         p.sendMessage(formattedMessage);
                     }
@@ -78,7 +77,6 @@ public class HelpOPChannel implements Channel {
                 }
             });
         }else{
-            String formattedMessage = String.format(format, player.getDisplayName(), message);
             for(Player p : members){
                 p.sendMessage(formattedMessage);
             }

--- a/strings-bukkit/src/main/java/com/pedestriamc/strings/chat/channels/ProximityChannel.java
+++ b/strings-bukkit/src/main/java/com/pedestriamc/strings/chat/channels/ProximityChannel.java
@@ -75,14 +75,13 @@ public class ProximityChannel implements Channel{
         String format = chatManager.formatMessage(player, this);
         message = chatManager.processMessage(player, message);
         String finalMessage = message;
+        String formattedMessage = format.replace("{message}", finalMessage);
 
         if(callEvent){
             Bukkit.getScheduler().runTask(strings, () ->{
                 AsyncPlayerChatEvent event = new ChannelChatEvent(false, player, finalMessage, receivers, this.getStringsChannel());
-                event.setFormat(format);
                 Bukkit.getPluginManager().callEvent(event);
                 if(!event.isCancelled()){
-                    String formattedMessage = String.format(event.getFormat(), strings.getUser(player).getDisplayName(), event.getMessage());
                     for(Player p : receivers){
                         p.sendMessage(formattedMessage);
                     }
@@ -93,7 +92,6 @@ public class ProximityChannel implements Channel{
             return;
         }
 
-        String formattedMessage = String.format(format, player.getDisplayName(), message);
         for(Player p : receivers){
             p.sendMessage(formattedMessage);
         }

--- a/strings-bukkit/src/main/java/com/pedestriamc/strings/chat/channels/StringChannel.java
+++ b/strings-bukkit/src/main/java/com/pedestriamc/strings/chat/channels/StringChannel.java
@@ -69,13 +69,12 @@ public class StringChannel implements Channel{
         String format = chatManager.formatMessage(player, this);
         message = chatManager.processMessage(player, message);
         String finalMessage = message;
+        String formattedMessage = format.replace("{message}", finalMessage);
         if(callEvent){
             Bukkit.getScheduler().runTask(strings, () -> {
                 AsyncPlayerChatEvent event = new ChannelChatEvent(false, player, finalMessage, getRecipients(), this.getStringsChannel());
-                event.setFormat(format);
                 Bukkit.getPluginManager().callEvent(event);
                 if(!event.isCancelled()){
-                    String formattedMessage = String.format(event.getFormat(), strings.getUser(player).getDisplayName(), event.getMessage());
                     for(Player p : getRecipients()){
                         p.sendMessage(formattedMessage);
                     }
@@ -84,7 +83,6 @@ public class StringChannel implements Channel{
                 }
             });
         }else{
-            String formattedMessage = String.format(format, player.getDisplayName(), message);
             for(Player p : getRecipients()){
                 p.sendMessage(formattedMessage);
             }

--- a/strings-bukkit/src/main/java/com/pedestriamc/strings/chat/channels/WorldChannel.java
+++ b/strings-bukkit/src/main/java/com/pedestriamc/strings/chat/channels/WorldChannel.java
@@ -71,13 +71,12 @@ public class WorldChannel implements Channel{
         String format = chatManager.formatMessage(player, this);
         message = chatManager.processMessage(player, message);
         String finalMessage = message;
+        String formattedMessage = format.replace("{message}", finalMessage);
         if(callEvent){
             Bukkit.getScheduler().runTask(strings, () ->{
                 AsyncPlayerChatEvent event = new ChannelChatEvent(false, player, finalMessage, getRecipients(), this.getStringsChannel());
-                event.setFormat(format);
                 Bukkit.getPluginManager().callEvent(event);
                 if(!event.isCancelled()){
-                    String formattedMessage = String.format(event.getFormat(), strings.getUser(player).getDisplayName(), event.getMessage());
                     for(Player p : getRecipients()){
                         p.sendMessage(formattedMessage);
                     }
@@ -86,7 +85,6 @@ public class WorldChannel implements Channel{
                 }
             });
         }else{
-            String formattedMessage = String.format(format, player.getDisplayName(), message);
             for(Player p : getRecipients()){
                 p.sendMessage(formattedMessage);
             }


### PR DESCRIPTION
Fix placeholder being formatted weirdly because of `String.format`

Before
![image](https://github.com/user-attachments/assets/6ad6df16-2fef-4c33-af6a-8151c0259512)

After
![image](https://github.com/user-attachments/assets/97fa5cf0-b550-4ba5-8dc5-b6f8c6db91f2)

both image are using this format

`format: "%player_name% {message}"`

---

reason it happen is, the plugin need both `{displayname}` and `{message}` respecetively to be present in the channels.yml `format: ` to be supplied into `.setFormat()` as `%s` following [AsyncPlayerChatEvent](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/event/player/AsyncPlayerChatEvent.html#setFormat(java.lang.String)) description __(is this part really necessary ?)__



above approach can also broke when `format: ` have another `%s`

example case is (Fixed with this PR)
- using PlaceholderAPI that start with `s` like `%server_name%` but then it fail to be formatted and leave it as `%server_name%` in chat
- having `%s` in `format: ` intentionally
  ![image](https://github.com/user-attachments/assets/d981bde2-635f-431e-bf47-2de75492360d)
  
  above image are using this format
  `format:"%s %player_name% {message}"`
 - this is when position of `{displayname}` and `{message}` is swapped
   ![image](https://github.com/user-attachments/assets/b8664d93-7d45-430e-81e7-52fefc8e9445)

   look normal but the `format: ` is not
   above image are using this format
   `format: "{message} > {displayname}"`
   
   fixed:
   ![image](https://github.com/user-attachments/assets/c9819e5e-e012-4dd2-a6a3-e8aa12928d84)



also this PR fix reload command

feel free to check